### PR TITLE
Implementing Dynamic Icon Theme Switching

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         "qapplication": "cpp",
         "editor.formatOnSave": "true",
         "clang-format.executable": "C:/Program Files/LLVM/bin/clang-format.exe"
-    }
+    },
+    "cmake.configureOnOpen": true
 }

--- a/iconManager.cpp
+++ b/iconManager.cpp
@@ -36,6 +36,7 @@ const QMap<QString, QIcon> &IconManager::getIconMap() const {
 
 void IconManager::switchTheme(bool isDarkTheme) {
   currentIconMap = isDarkTheme ? &iconMapDark : &iconMapLight;
+  emit themeChanged();
 }
 
 const QMap<QString, QString> &IconManager::getIconPaths() const {

--- a/iconManager.h
+++ b/iconManager.h
@@ -4,8 +4,12 @@
 #include <QMap>
 #include <QString>
 #include <QIcon>
+#include <QObject>
+#include <QToolButton>
 
-class IconManager {
+class IconManager : public QObject {
+  Q_OBJECT
+
 public:
   IconManager();
 
@@ -14,6 +18,11 @@ public:
   const QMap<QString, QIcon>& getIconMap() const;
   const QMap<QString, QString>& getIconPaths() const;
   static QPixmap recolorPixmap(const QPixmap& pixmap, const QColor& color);
+
+signals:
+  void themeChanged();
+
+public slots:
   void switchTheme(bool isDarkTheme);
 
 private:
@@ -21,6 +30,26 @@ private:
   QMap<QString, QIcon> iconMapDark;
   QMap<QString, QIcon>* currentIconMap;
   QMap<QString, QString> iconPaths;
+};
+
+class TToolButton : public QToolButton {
+  Q_OBJECT
+
+public:
+  TToolButton(IconManager* iconManager, const QString& iconName, QWidget* parent = nullptr)
+    : QToolButton(parent), m_iconManager(iconManager), m_iconName(iconName) {
+    setIcon(iconManager->getIcon(iconName));
+    connect(iconManager, &IconManager::themeChanged, this, &TToolButton::updateIcon);
+  }
+
+public slots:
+  void updateIcon() {
+    setIcon(m_iconManager->getIcon(m_iconName));
+  }
+
+private:
+  IconManager* m_iconManager;
+  QString m_iconName;
 };
 
 #endif  // ICONMANAGER_H

--- a/main.cpp
+++ b/main.cpp
@@ -50,13 +50,11 @@ int main(int argc, char *argv[]) {
                      settings.setValue("checkBoxStatus", checkBox->isChecked());
                    });
 
-  // create a toolButton containing an icon for testing
-  QToolButton toolButton;
-  toolButton.setIcon(iconManager.getIcon("brush"));
+  TToolButton *toolButton = new TToolButton(&iconManager, "brush");
 
   // build the layout
   layout->addWidget(checkBox);
-  layout->addWidget(&toolButton);
+  layout->addWidget(toolButton);
 
   // build the window
   w.setCentralWidget(centralWidget);


### PR DESCRIPTION
Created `IconManager` class, which manages icon themes, a light theme and dark theme. The class reads icons from a specified path and generates two versions of each icon (light and dark) by `recoloring` the original images. It stores these icon versions in two separate `QMaps` (`iconMapLight` and `iconMapDark`), mapping icon names to `QIcon` objects.

The `currentIconMap` pointer points to the currently active icon map. This enables us to retrieve the right version of the icon based on the current theme by calling `IconManager::getIcon()`.

The `IconManager::switchtheme(bool)` is a function that switches the current icon theme. This is one by updating the `currentIconMap` pointer to point to the corresponding icon map (`iconMapDark` for dark theme, `iconMapLight` for light theme). When this function is called, it emits a `themeChanged()` signal.

I created a custom widget `TToolButton` that inherits from `QToolButton`. This widget takes an IconManager instance and an icon name as params. When a `themeChanged()` signal is emitted, `TToolButton` responds by calling its `updateIcon()` slot function, which updates its icon to the current theme's version using the `IconManager::getIcon()` function.

Finally, we connected the `themeChanged()` signal to the `updateIcon()` slot function for all instances of `TToolButton`. This ensures that every icon in the application is updated whenever the theme is changed.